### PR TITLE
Add shinyjs in vignette to clean the URL after authentication

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,6 +3,7 @@ Title: Authentication Services for Azure Active Directory
 Version: 1.3.1.9000
 Authors@R: c(
     person("Hong", "Ooi", , "hongooi73@gmail.com", role = c("aut", "cre")),
+    person("Tyler", "Littlefield", role="ctb"),
     person("httr development team", role="ctb", comment="Original OAuth listener code"),
     person("Scott", "Holden", , role = "ctb", comment = "Advice on AAD authentication"),
     person("Chris", "Stone", , role = "ctb", comment = "Advice on AAD authentication"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: AzureAuth
 Title: Authentication Services for Azure Active Directory
-Version: 1.3.1
+Version: 1.3.1.9000
 Authors@R: c(
     person("Hong", "Ooi", , "hongooi73@gmail.com", role = c("aut", "cre")),
     person("httr development team", role="ctb", comment="Original OAuth listener code"),
@@ -29,6 +29,7 @@ Suggests:
     testthat,
     httpuv,
     shiny,
+    shinyjs,
     AzureRMR,
     AzureGraph
 Roxygen: list(markdown=TRUE, r6=FALSE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# AzureAuth 1.3.1.9000
+
+- Update Shiny vignette to clean up redirect page after authenticating (thanks to Tyler Littlefield).
+
 # AzureAuth 1.3.1
 
 - Allow specifying the location of the token caching directory in the environment variable `R_AZURE_DATA_DIR`.

--- a/vignettes/shiny.Rmd
+++ b/vignettes/shiny.Rmd
@@ -3,9 +3,9 @@ title: "Authenticating from Shiny"
 author: Hong Ooi
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Shiny}
-  %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteEncoding{utf8}
+    %\VignetteIndexEntry{Shiny}
+    %\VignetteEngine{knitr::rmarkdown}
+    %\VignetteEncoding{utf8}
 ---
 
 Because a Shiny app has separate UI and server components, the interactive authentication flows require some changes. In particular, the authorization step (logging in to Azure) has to be conducted separately from the token acquisition step.
@@ -49,15 +49,15 @@ ui_func <- function(req)
 
 # code for cleaning url after authentication
 clean_url_js <- sprintf(
-  "
-  $(document).ready(function(event) {
-    const nextURL = '%s';
-    const nextTitle = 'My new page title';
-    const nextState = { additionalInformation: 'Updated the URL with JS' };
-    // This will create a new entry in the browser's history, without reloading
-    window.history.pushState(nextState, nextTitle, nextURL);
-  });
-  ", redirect
+    "
+    $(document).ready(function(event) {
+      const nextURL = '%s';
+      const nextTitle = 'My new page title';
+      const nextState = { additionalInformation: 'Updated the URL with JS' };
+      // This will create a new entry in the browser's history, without reloading
+      window.history.pushState(nextState, nextTitle, nextURL);
+    });
+    ", redirect
 )
 
 server <- function(input, output, session)

--- a/vignettes/shiny.Rmd
+++ b/vignettes/shiny.Rmd
@@ -12,11 +12,12 @@ Because a Shiny app has separate UI and server components, the interactive authe
 
 AzureAuth provides the `build_authorization_uri` function to facilitate this separation. You call this function to obtain a URI that you browse to in order to login to Azure. Once you have logged in, Azure will return an authorization code as part of a redirect.
 
-Here is a skeleton Shiny app that demonstrates its use. The UI calls `build_authorization_uri`, and then redirects your browser to that location. When you have logged in, the server captures the authorization code and calls `get_azure_token` to obtain the token.
+Here is a skeleton Shiny app that demonstrates its use. The UI calls `build_authorization_uri`, and then redirects your browser to that location. When you have logged in, the server captures the authorization code and calls `get_azure_token` to obtain the token. Once the token is obtained, `shinyjs` is used to return the URL back to its original state.
 
 ```r
 library(AzureAuth)
 library(shiny)
+library(shinyjs)
 
 resource <- "https://management.azure.com"
 tenant <- "your-tenant-here"
@@ -30,6 +31,7 @@ options(shiny.port=as.numeric(httr::parse_url(redirect)$port))
 
 # replace this with your app's regular UI
 ui <- fluidPage(
+    useShinyjs(),
     verbatimTextOutput("token")
 )
 
@@ -45,8 +47,23 @@ ui_func <- function(req)
     else ui
 }
 
+# code for cleaning url after authentication
+clean_url_js <- sprintf(
+  "
+  $(document).ready(function(event) {
+    const nextURL = '%s';
+    const nextTitle = 'My new page title';
+    const nextState = { additionalInformation: 'Updated the URL with JS' };
+    // This will create a new entry in the browser's history, without reloading
+    window.history.pushState(nextState, nextTitle, nextURL);
+  });
+  ", redirect
+)
+
 server <- function(input, output, session)
 {
+    shinyjs::runjs(clean_url_js)
+
     opts <- parseQueryString(isolate(session$clientData$url_search))
     if(is.null(opts$code))
         return()


### PR DESCRIPTION
With this change, users should have their shiny apps URL restored to whatever they put in `redirect` and refreshing the app will no longer complain about reusing an old token. Closes #41 